### PR TITLE
Add Makefile that combines Lecture Note pdfs

### DIFF
--- a/METU-EE402/Makefile
+++ b/METU-EE402/Makefile
@@ -1,0 +1,18 @@
+OUTDIR=./AllLectures/
+
+$(OUTDIR):
+	mkdir -p -v $(OUTDIR)
+	cp Lecture\ 1/EE_402_Lecture_1.pdf $(OUTDIR)/
+	cp Lecture\ */EE402_Lecture_*.pdf $(OUTDIR)/
+	mv $(OUTDIR)/EE_402_Lecture_1.pdf $(OUTDIR)/EE402_Lecture_01.pdf
+	mv $(OUTDIR)/EE402_Lecture_2.pdf $(OUTDIR)/EE402_Lecture_02.pdf
+	mv $(OUTDIR)/EE402_Lecture_3.pdf $(OUTDIR)/EE402_Lecture_03.pdf
+	mv $(OUTDIR)/EE402_Lecture_4.pdf $(OUTDIR)/EE402_Lecture_04.pdf
+	mv $(OUTDIR)/EE402_Lecture_5.pdf $(OUTDIR)/EE402_Lecture_05.pdf
+	mv $(OUTDIR)/EE402_Lecture_6.pdf $(OUTDIR)/EE402_Lecture_06.pdf
+	mv $(OUTDIR)/EE402_Lecture_7.pdf $(OUTDIR)/EE402_Lecture_07.pdf
+	mv $(OUTDIR)/EE402_Lecture_8.pdf $(OUTDIR)/EE402_Lecture_08.pdf
+	mv $(OUTDIR)/EE402_Lecture_9.pdf $(OUTDIR)/EE402_Lecture_09.pdf
+	qpdf --empty --pages $(OUTDIR)/*pdf -- AllLectures.pdf
+	rm -r $(OUTDIR)
+	

--- a/METU-EE402/README.md
+++ b/METU-EE402/README.md
@@ -1,0 +1,14 @@
+# EE402
+
+### Combining Lectures:
+
+Tested in Ubuntu.
+
+From this directory `Lecture-Notes/METU-EE402`:
+
+```sudo apt-get install make qpdf
+make```
+
+Resulting pdf will be in this directory:
+
+`Lecture-Notes/METU-EE402/AllLectures.pdf`

--- a/METU-EE402/README.md
+++ b/METU-EE402/README.md
@@ -6,8 +6,10 @@ Tested in Ubuntu.
 
 From this directory `Lecture-Notes/METU-EE402`:
 
-```sudo apt-get install make qpdf
-make```
+```
+sudo apt-get install make qpdf
+make
+```
 
 Resulting pdf will be in this directory:
 


### PR DESCRIPTION
From Ubuntu, and probably other Linux distributions, merging lecture note pdfs is as easy as running the `make` command from the terminal.