### PR TITLE
Correction of difference equation notation

### DIFF
--- a/METU-EE402/Lecture 3/EE402_Lecture_3.tex
+++ b/METU-EE402/Lecture 3/EE402_Lecture_3.tex
@@ -381,7 +381,7 @@ inverse Z-transform of both sides by applying the shifting theorem
 we obtain
 %
 \begin{align*}
-a_0 y[k] + a_{1} y[k-1] + ... + a_N z^{-N} y[k-N] &= b_0 x[k] + b_{1}
+a_0 y[k] + a_{1} y[k-1] + ... + a_N y[k-N] &= b_0 x[k] + b_{1}
 x[k-1] + ... + b_M x[k-M]
 \end{align*}
 %


### PR DESCRIPTION
Hocam, I think there should not be z^-N term in difference equation representation. Am I wrong?