### PR TITLE
Correction in canonical realization

### DIFF
--- a/METU-EE402/Lecture 4/EE402_Lecture_4.tex
+++ b/METU-EE402/Lecture 4/EE402_Lecture_4.tex
@@ -260,7 +260,7 @@ As you can see we introduced an intermediate variable $h[k]$ with a
 Z-transform of $H(z)$, First transfer function, which is an IIR system
 with static input dynamics operates on $x[n]$ and produces an output. 
 Second transfer function operates on $h[n]$ and produces output
-$x[n]$. If we write the difference equations of both systems we obtain
+$y[n]$. If we write the difference equations of both systems we obtain
 %
 \begin{align*}
 h[k] &= -a_1 h[y-1] - a_2 h[k-2] - a_3 h[k-3] + x[k] 


### PR DESCRIPTION
I think operations on h[k] will produce output of y[n] because second transfer function is in the form of Y(Z)/H(Z).